### PR TITLE
Remove generic cybersecurity AI entries from research list

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -775,81 +775,6 @@
   },
   {
     "id": 26,
-    "title": "CAI: An Open, Bug Bounty-Ready Cybersecurity AI",
-    "year": "08 Apr 2025",
-    "summary": "Introduces a modular cybersecurity AI agent designed to automate reconnaissance, exploitation, and reporting workflows for coordinated vulnerability disclosure programs.",
-    "sources": [
-      {
-        "type": "paper",
-        "title": "CAI: An Open, Bug Bounty-Ready Cybersecurity AI",
-        "url": "https://arxiv.org/abs/2504.06017"
-      },
-      {
-        "type": "pdf",
-        "title": "PDF",
-        "url": "http://arxiv.org/pdf/2504.06017"
-      }
-    ],
-    "tags": [
-      "Cybersecurity AI",
-      "Bug Bounty",
-      "Autonomous Operations",
-      "Vulnerability Discovery"
-    ],
-    "last_reviewed": "24 Sep 2025"
-  },
-  {
-    "id": 27,
-    "title": "Cybersecurity AI: The Dangerous Gap Between Automation and Autonomy",
-    "year": "30 Jun 2025",
-    "summary": "Analyzes how partially automated security tooling can overstep into unsupervised autonomy, outlining governance safeguards to prevent AI-driven operations from escalating beyond human intent.",
-    "sources": [
-      {
-        "type": "paper",
-        "title": "Cybersecurity AI: The Dangerous Gap Between Automation and Autonomy",
-        "url": "https://arxiv.org/abs/2506.23592"
-      },
-      {
-        "type": "pdf",
-        "title": "PDF",
-        "url": "http://arxiv.org/pdf/2506.23592"
-      }
-    ],
-    "tags": [
-      "Cybersecurity AI",
-      "Automation Risk",
-      "Governance",
-      "Operational Safety"
-    ],
-    "last_reviewed": "24 Sep 2025"
-  },
-  {
-    "id": 28,
-    "title": "CAI Fluency: A Framework for Cybersecurity AI Fluency",
-    "year": "27 Aug 2025",
-    "summary": "Proposes a competency framework that measures practitioner fluency when collaborating with cybersecurity AI systems, mapping skill levels to operational tasks and training resources.",
-    "sources": [
-      {
-        "type": "paper",
-        "title": "CAI Fluency: A Framework for Cybersecurity AI Fluency",
-        "url": "https://arxiv.org/abs/2508.13588"
-      },
-      {
-        "type": "pdf",
-        "title": "PDF",
-        "url": "http://arxiv.org/pdf/2508.13588"
-      }
-    ],
-    "tags": [
-      "Cybersecurity AI",
-      "Training Framework",
-      "Human Factors",
-      "Operational Readiness"
-    ],
-    "last_reviewed": "24 Sep 2025"
-  },
-  {
-    "id": 29,
     "title": "Robot Hacking Manual (RHM)",
     "year": "09 Mar 2022",
     "summary": "Compiles offensive security techniques for industrial and service robots, covering attack surfaces from network middleware to safety controllers with reproducible lab setups.",
@@ -874,7 +799,7 @@
     "last_reviewed": "24 Sep 2025"
   },
   {
-    "id": 30,
+    "id": 27,
     "title": "Offensive Robot Cybersecurity",
     "year": "23 Jun 2025",
     "summary": "Details a red-teaming methodology for robotic platforms that couples adversarial simulation, exploit development, and mitigations tailored to autonomous systems.",
@@ -899,57 +824,7 @@
     "last_reviewed": "24 Sep 2025"
   },
   {
-    "id": 31,
-    "title": "PentestGPT: An LLM-empowered Automatic Penetration Testing Tool",
-    "year": "13 Aug 2023",
-    "summary": "Presents an LLM-driven agent that plans and executes penetration testing steps, combining language-based reasoning with tool integrations for autonomous exploit discovery.",
-    "sources": [
-      {
-        "type": "paper",
-        "title": "PentestGPT: An LLM-empowered Automatic Penetration Testing Tool",
-        "url": "https://arxiv.org/abs/2308.06782"
-      },
-      {
-        "type": "pdf",
-        "title": "PDF",
-        "url": "http://arxiv.org/pdf/2308.06782"
-      }
-    ],
-    "tags": [
-      "Penetration Testing",
-      "Large Language Models",
-      "Automation",
-      "Offensive Security"
-    ],
-    "last_reviewed": "24 Sep 2025"
-  },
-  {
-    "id": 32,
-    "title": "Cybersecurity AI: Hacking the AI Hackers via Prompt Injection",
-    "year": "29 Aug 2025",
-    "summary": "Demonstrates how malicious prompts can subvert defensive cybersecurity agents, offering mitigations that harden instruction pipelines against jailbreaks and data exfiltration.",
-    "sources": [
-      {
-        "type": "paper",
-        "title": "Cybersecurity AI: Hacking the AI Hackers via Prompt Injection",
-        "url": "https://arxiv.org/abs/2508.21669"
-      },
-      {
-        "type": "pdf",
-        "title": "PDF",
-        "url": "http://arxiv.org/pdf/2508.21669"
-      }
-    ],
-    "tags": [
-      "Prompt Injection",
-      "Cybersecurity AI",
-      "Adversarial NLP",
-      "Defense Evasion"
-    ],
-    "last_reviewed": "24 Sep 2025"
-  },
-  {
-    "id": 33,
+    "id": 28,
     "title": "SoK: Cybersecurity Assessment of Humanoid Ecosystem",
     "year": "27 Aug 2025",
     "summary": "Systematizes known vulnerabilities across humanoid robot hardware, software supply chains, and cloud services, prioritizing mitigations for safety-critical deployments.",
@@ -974,7 +849,7 @@
     "last_reviewed": "24 Sep 2025"
   },
   {
-    "id": 34,
+    "id": 29,
     "title": "DevSecOps in Robotics",
     "year": "23 Mar 2020",
     "summary": "Advocates for integrating security practices into the robotics software lifecycle, outlining continuous integration, testing, and deployment controls tailored to ROS ecosystems.",
@@ -999,7 +874,7 @@
     "last_reviewed": "24 Sep 2025"
   },
   {
-    "id": 35,
+    "id": 30,
     "title": "Alurity: A Systematic Review on the Security of Robotic and Autonomous Systems",
     "year": "25 Mar 2022",
     "summary": "Surveys research on cyber-physical threats to robots and autonomous platforms, synthesizing mitigation strategies across networking, perception, and control layers.",


### PR DESCRIPTION
## Summary
- remove generic cybersecurity AI entries with ids 26, 27, 28, 31, and 32 that focus on non-multimodal LLM agents
- renumber the remaining entries so the research list uses sequential IDs without gaps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d476341da8832ebdd30c11a96f247a